### PR TITLE
Add prev/next navigation tables to all chapters

### DIFF
--- a/00-foundations/01-the-new-literacy.md
+++ b/00-foundations/01-the-new-literacy.md
@@ -69,3 +69,9 @@ Then in Phase 1, you'll start talking to agents and build your first project. By
 You already have everything you need to start. You can think. You can communicate. You can tell when something works and when it doesn't. Everything else is practice.
 
 Let's go.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Forward](../FORWARD.md) | **The New Literacy** | [What Code Actually Is →](02-what-code-actually-is.md) |

--- a/00-foundations/02-what-code-actually-is.md
+++ b/00-foundations/02-what-code-actually-is.md
@@ -65,3 +65,9 @@ Code is not magic. It's instructions that store information, make decisions, rep
 You now have enough understanding of what code *is* to direct an agent that writes it. You don't need to go deeper. Syntax, language-specific features, algorithmic optimization: that's the agent's job. Your job is to know what you want built and describe it in terms of what it stores, decides, repeats, and communicates.
 
 That's the mental model. Now let's set up your workspace.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← The New Literacy](01-the-new-literacy.md) | **What Code Actually Is** | [The Language Landscape →](03-the-language-landscape.md) |

--- a/00-foundations/03-the-language-landscape.md
+++ b/00-foundations/03-the-language-landscape.md
@@ -142,3 +142,9 @@ Now try one more thing. Tell the agent:
 Run it. Test it. Type a few names, then type "quit." Does it exit cleanly? What happens if you type nothing and just press enter? What happens if you type a very long string? You're already practicing verification and edge-case thinking, and you've only been writing Rust for five minutes.
 
 When you're done, this project lives in your `scratch/` folder. It's not a portfolio piece. It's just proof that you've touched the compiler and it didn't bite. When Phase 2 asks you to build a real CLI tool in Rust, you'll know the basics already: `cargo new`, `cargo run`, and directing an agent to write the code.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← What Code Actually Is](02-what-code-actually-is.md) | **The Language Landscape** | [Your Workspace →](04-your-workspace.md) |

--- a/00-foundations/04-your-workspace.md
+++ b/00-foundations/04-your-workspace.md
@@ -151,3 +151,9 @@ A quick list of things that might seem like prerequisites but aren't:
 - **Prior experience.** If you've read this far, you have enough.
 
 You're set up. Next we'll cover just enough git to track your work, and then you're ready to start talking to agents.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← The Language Landscape](03-the-language-landscape.md) | **Your Workspace** | [Git: Just Enough →](05-git-just-enough.md) |

--- a/00-foundations/05-git-just-enough.md
+++ b/00-foundations/05-git-just-enough.md
@@ -189,3 +189,9 @@ The seven commands above are enough to track your work, share your portfolio, an
 Git is your project's memory and your portfolio's backbone. Seven commands handle everything you need: `init`, `clone`, `status`, `add`, `commit`, `push`, `pull`. Use them in the work-status-add-commit-push loop, and your entire journey gets recorded.
 
 You now have everything you need for Phase 0. You understand what code is (conceptually), your workspace is set up, and you can track and share your work. Time to learn how to actually talk to agents.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Your Workspace](04-your-workspace.md) | **Git: Just Enough** | [How Agents Think →](../01-talking-to-agents/01-how-agents-think.md) |

--- a/01-talking-to-agents/01-how-agents-think.md
+++ b/01-talking-to-agents/01-how-agents-think.md
@@ -79,3 +79,9 @@ Here's what all of this means for your day-to-day work:
 5. **Iterate.** Your first attempt will rarely be perfect. The power is in the speed of iteration: ask, review, refine, repeat. The agent can do this loop a hundred times in the time it would take to do it once by hand.
 
 Now that you understand how your collaborator works, let's learn how to talk to it.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Git: Just Enough](../00-foundations/05-git-just-enough.md) | **How Agents Think** | [The Art of Intent →](02-the-art-of-intent.md) |

--- a/01-talking-to-agents/02-the-art-of-intent.md
+++ b/01-talking-to-agents/02-the-art-of-intent.md
@@ -159,3 +159,9 @@ Try writing prompts for each of these using the five questions and the template 
 Write these out and share them in the guild. Getting feedback on your prompts before building is great practice, and it's the earliest form of the adversarial refinement that defines our methodology.
 
 Next up: why context is the invisible factor that makes or breaks every interaction with an agent.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← How Agents Think](01-how-agents-think.md) | **The Art of Intent** | [Context Is Everything →](03-context-is-everything.md) |

--- a/01-talking-to-agents/03-context-is-everything.md
+++ b/01-talking-to-agents/03-context-is-everything.md
@@ -109,3 +109,9 @@ You won't go through this formally every time. With practice, it becomes instinc
 3. Write a one-paragraph "context summary" for a project idea you have, something you could paste at the start of any conversation to instantly ground the agent. Share it in the guild for feedback.
 
 Next: the most important skill in agentic development, breaking problems into manageable pieces.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← The Art of Intent](02-the-art-of-intent.md) | **Context Is Everything** | [Breaking Problems Down →](04-breaking-problems-down.md) |

--- a/01-talking-to-agents/04-breaking-problems-down.md
+++ b/01-talking-to-agents/04-breaking-problems-down.md
@@ -108,3 +108,9 @@ The agent will produce a breakdown. Review it critically. Does the order make se
 4. Share your decomposition in the guild channel and ask for feedback. Can other members spot dependencies you missed? Steps that could be broken down further? This is lightweight adversarial review, exactly the kind of thinking the guild develops.
 
 You've now covered the fundamentals of working with agents: understanding how they think, communicating your intent, providing context, and breaking problems down. Time to put it all together and build something real.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Context Is Everything](03-context-is-everything.md) | **Breaking Problems Down** | [Your First Build →](05-first-build.md) |

--- a/01-talking-to-agents/05-first-build.md
+++ b/01-talking-to-agents/05-first-build.md
@@ -222,3 +222,9 @@ Some ideas for self-directed projects:
 Choose things you'll actually use. The best portfolio projects solve your own real problems. They show not just technical ability but the judgment to identify problems worth solving.
 
 You have the methodology. You have the tools. Go build something.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Breaking Problems Down](04-breaking-problems-down.md) | **Your First Build** | [When Things Break →](06-when-things-break.md) |

--- a/01-talking-to-agents/06-when-things-break.md
+++ b/01-talking-to-agents/06-when-things-break.md
@@ -136,3 +136,9 @@ This loop handles 95% of problems. The other 5% are where you learn the most, an
 2. Ask your agent to build something slightly ambiguous on purpose: "make a timer." Don't specify what kind of timer, what it counts, or how it displays. Look at what you get. Identify every gap between what you wanted and what the agent assumed. Write the corrected prompt that would have gotten the right result the first time.
 
 3. Start a conversation with your agent and build something small (a unit converter, a tip calculator, whatever). When it works, break it by asking for a feature that conflicts with the existing code: "now make it work backwards too." Watch how the agent handles the conflict. If it introduces a bug, practice the debugging loop: read the error, share it back, iterate.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Your First Build](05-first-build.md) | **When Things Break** | [Finding Answers →](07-finding-answers.md) |

--- a/01-talking-to-agents/07-finding-answers.md
+++ b/01-talking-to-agents/07-finding-answers.md
@@ -93,3 +93,9 @@ This isn't adversarial. It's verification. The same principle from VDD applied t
 2. Introduce a version mismatch on purpose. Ask your agent to use an old pattern from a library (it will probably do this naturally if you just ask "use [library]" without specifying a version). When it breaks, find the changelog, identify what changed, and use the current documentation to fix it.
 
 3. Find a Rust error message you don't understand. Before asking the agent, search for the exact error text online. Read the first few results. Then ask the agent to explain it. Which explanation was more helpful? Which was faster? This builds your intuition for when to search vs when to ask.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← When Things Break](06-when-things-break.md) | **Finding Answers** | [How We Build →](../02-the-methodology/01-how-we-build.md) |

--- a/02-the-methodology/01-how-we-build.md
+++ b/02-the-methodology/01-how-we-build.md
@@ -189,3 +189,9 @@ As an apprentice, you're not going to set up formal verification pipelines or ru
 4. Share your adversarial review experience in the guild channel. What was the most useful critique you received? What was the hardest to fix? What did you learn about your own blind spots?
 
 This methodology is the backbone of everything we do in the guild. The tools will change, the agents will get better, the specific techniques will evolve. But the core loop (build, verify, get roasted, fix, repeat) works because it's built on honest feedback and hard evidence. That doesn't go out of date.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Finding Answers](../01-talking-to-agents/07-finding-answers.md) | **How We Build** | [Tracking Your Work →](02-tracking-your-work.md) |

--- a/02-the-methodology/02-tracking-your-work.md
+++ b/02-the-methodology/02-tracking-your-work.md
@@ -261,3 +261,9 @@ This is the tracking layer of VDD. The beads on the string. Every piece of work 
 4. Start a new conversation with your agent in a Chainlink-enabled project. Don't give it any context. Just say "check where we left off and let's keep going." See how quickly it picks up the thread from the handoff notes and issue list. Compare this to the old approach of typing a paragraph of context every time.
 
 5. Submit your issue tracker for adversarial review. The roast for this one will be interesting, because your reviewers are people who *use* issue trackers every day. They'll have opinions.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← How We Build](01-how-we-build.md) | **Tracking Your Work** | [The Workshop →](../03-real-world-skills/01-the-workshop.md) |

--- a/03-real-world-skills/01-the-workshop.md
+++ b/03-real-world-skills/01-the-workshop.md
@@ -152,3 +152,9 @@ Skills this teaches that nothing else in the curriculum does:
 3. Review someone else's PR on the toolkit. Read their code, test it locally, and leave specific feedback. This is your first time being the reviewer rather than the reviewed. Be constructive and specific, just like the best roast feedback you've received.
 
 4. After your first PR is merged, find an issue on an intermediate tool. Notice how the process feels different when you already know the codebase.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Tracking Your Work](../02-the-methodology/02-tracking-your-work.md) | **The Workshop** | [Working with APIs →](02-working-with-apis.md) |

--- a/03-real-world-skills/02-working-with-apis.md
+++ b/03-real-world-skills/02-working-with-apis.md
@@ -153,3 +153,9 @@ This is adversarial thinking applied to external services. The happy path is eas
 3. Take the tool from exercise 2 and check if an MCP server exists for that same API. If it does, compare the two approaches: which was faster to build? Which is easier to maintain? Which would you choose for a tool you plan to distribute to others?
 
 4. Write a skill (a markdown file in `.claude/`) that packages up a common API workflow you find yourself repeating. For example, a skill that checks the status of your GitHub PRs, or one that looks up documentation for a library. Save it and use it with your agent. Notice how a good skill saves you from re-explaining context every time.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← The Workshop](01-the-workshop.md) | **Working with APIs** | [Project Architecture →](03-project-architecture.md) |

--- a/03-real-world-skills/03-project-architecture.md
+++ b/03-real-world-skills/03-project-architecture.md
@@ -173,3 +173,9 @@ If the answer to any of these is no, push back before a single line of code exis
 3. Start a new project (anything you want) and begin with the architecture conversation. Before any code exists, have the agent help you plan the module structure. Save the plan as a section in your design doc. Then build, following the plan. Notice how much smoother the build process is when the structure is decided upfront.
 
 4. Deliberately ask your agent to add three features to a project without giving any architectural direction. Just say "add X," "add Y," "add Z." Then look at what happened. Where did the code end up? Is there duplication? Is anything hard to find? Now refactor with explicit architectural direction. Compare the two experiences.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Working with APIs](02-working-with-apis.md) | **Project Architecture** | [Security →](04-security.md) |

--- a/03-real-world-skills/04-security.md
+++ b/03-real-world-skills/04-security.md
@@ -173,3 +173,9 @@ Security isn't a phase you do at the end. It's a consideration at every stage:
 3. Review another guild member's code specifically for security. Use the security adversary checklist. Write up your findings with specific line references and suggested fixes. This is harder than it sounds because you need to read code you didn't write and reason about how it could be exploited.
 
 4. Build a security scanner CLI tool in Rust. It should take a project path as input and run a series of checks: cargo audit, cargo deny, clippy security lints, and then use an AI agent (via API or MCP) to do an automated security review of the source code. Aggregate the results into a report with severity levels. This is an advanced project: it involves file I/O, process spawning, API integration, and output formatting. It could become a tool in the guild toolkit.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Project Architecture](03-project-architecture.md) | **Security** | [Shipping It →](05-shipping-it.md) |

--- a/03-real-world-skills/05-shipping-it.md
+++ b/03-real-world-skills/05-shipping-it.md
@@ -313,3 +313,9 @@ Before you ship anything, run through this:
 4. Package one of your projects for distribution. Create a GitHub release with a built binary. Write a README that explains what it is, how to install it, and how to use it. Have someone else (another guild member, a friend) try to use it from just the README and release binary. Their experience will teach you more about shipping than any guide can.
 
 5. Set up a GitHub Actions workflow that runs your full test suite (tests, clippy, formatting) on every push. Make it test on at least two platforms. Watch it catch something you missed locally. This is the beginning of CI/CD, and it's how professional projects stay healthy.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Security](04-security.md) | **Shipping It** | [On Your Own →](../04-proving-it/01-on-your-own.md) |

--- a/04-proving-it/01-on-your-own.md
+++ b/04-proving-it/01-on-your-own.md
@@ -74,3 +74,9 @@ A simple tool that's beautifully designed, thoroughly tested, honestly documente
 There's no deadline. Some apprentices will finish their capstone in a few weeks. Some will take months. The guild doesn't rush this. What matters is that the work is solid when it's submitted, not that it was fast.
 
 That said, don't let it become the project that's never done. Scope it to something you can ship, ship it, and then improve it over time if you want. Shipped and imperfect beats unshipped and theoretical every time.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Shipping It](../03-real-world-skills/05-shipping-it.md) | **On Your Own** | [Giving Back →](02-giving-back.md) |

--- a/04-proving-it/02-giving-back.md
+++ b/04-proving-it/02-giving-back.md
@@ -51,3 +51,9 @@ This document goes in your portfolio. It's evidence of a skill that most people 
 The ability to explain technical concepts to people who don't share your context is one of the most valuable skills in any technical career. It's how you write good documentation. It's how you onboard new team members. It's how you communicate with non-technical stakeholders. It's how you lead.
 
 Most technical education completely ignores this. You learn to build things but not to explain them. The guild doesn't make that mistake. You build, and then you explain what you built, and then you help someone else build. The full cycle.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← On Your Own](01-on-your-own.md) | **Giving Back** | [The Portfolio Review →](03-the-portfolio-review.md) |

--- a/04-proving-it/03-the-portfolio-review.md
+++ b/04-proving-it/03-the-portfolio-review.md
@@ -143,3 +143,9 @@ So you have two things: a certificate that marks your achievement and a portfoli
 You started this path with the ability to think and communicate. You end it with a body of work that proves you can direct intelligent systems to build things that work, and the process discipline to do it reliably. Everything else you'll learn on the job, because you've proven you know how to learn.
 
 Welcome to the journeymanship.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← Giving Back](02-giving-back.md) | **The Portfolio Review** | |

--- a/FORWARD.md
+++ b/FORWARD.md
@@ -67,3 +67,9 @@ Check your ego at the door. Accept that you'll be wrong more often than you're r
 In return, you'll develop real skill. Not memorized facts, not credentials, not the ability to pass a test. The ability to direct intelligent systems to build things that work, verified by evidence and hardened by honest critique. That's worth being wrong a few hundred times.
 
 Let's begin.
+
+---
+
+| Previous | Current | Next |
+|:---|:---:|---:|
+| [← README](README.md) | **Forward** | [The New Literacy →](00-foundations/01-the-new-literacy.md) |


### PR DESCRIPTION
Links every chapter file together in reading order, from FORWARD.md through the four phases, with relative-path navigation tables at the end of each file. Authored by Claude but double-checked that the order is correct.

It makes the onboarding feel a little more like a book, which is nice.